### PR TITLE
Add Cypress and Vitest test suites with CI integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Run end-to-end tests
+        run: npm run test:e2e

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://127.0.0.1:4173',
+    specPattern: 'tests/e2e/**/*.cy.{js,jsx,ts,tsx}',
+    supportFile: 'tests/e2e/support/e2e.js',
+    video: false
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "vite --host 0.0.0.0",
+    "dev:test": "vite --host 127.0.0.1 --port 4173",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0",
     "server:dev": "nodemon server.js",
@@ -15,7 +16,9 @@
     "fresh-install": "npm run clean && npm install",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix",
-    "test": "vitest run",
+    "test": "npm run test:unit",
+    "test:unit": "vitest run",
+    "test:e2e": "start-server-and-test dev:test http://127.0.0.1:4173 \"cypress run\"",
     "test:coverage": "vitest run --coverage"
   },
   "keywords": [
@@ -69,7 +72,9 @@
     "nodemon": "^3.1.7",
     "eslint": "^9.15.0",
     "vitest": "^2.1.4",
-    "@vitest/coverage-v8": "^2.1.4"
+    "@vitest/coverage-v8": "^2.1.4",
+    "cypress": "^13.15.0",
+    "start-server-and-test": "^2.0.3"
   },
   "repository": {
     "type": "git",

--- a/tests/e2e/auth.cy.js
+++ b/tests/e2e/auth.cy.js
@@ -1,0 +1,232 @@
+/// <reference types="cypress" />
+
+describe('Fluxos de autenticação e proteção de sessão', () => {
+  afterEach(() => {
+    cy.mockSupabase(null);
+  });
+
+  it('realiza login com credenciais válidas e redireciona para o dashboard', () => {
+    const signInStub = cy.stub().as('genericSignIn').resolves({
+      data: { user: { id: 'user-123', email: 'user@example.com' } },
+      error: null
+    });
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+    const sessionStub = cy.stub().resolves({ user: null });
+
+    cy.mockSupabase({
+      genericSignIn: signInStub,
+      createAuditLog: auditStub,
+      getCurrentSession: sessionStub
+    });
+
+    cy.clock();
+    cy.visit('/login.html');
+
+    cy.get('#email').type('user@example.com');
+    cy.get('#password').type('SenhaSegura1!');
+    cy.get('#login-form').submit();
+
+    cy.get('#success-message').should('contain', 'Login realizado com sucesso');
+    cy.get('@genericSignIn').should('have.been.calledWith', 'user@example.com', 'SenhaSegura1!');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'LOGIN_SUCCESS', Cypress.sinon.match({ user_id: 'user-123' }));
+
+    cy.tick(1000);
+    cy.location('pathname').should('eq', '/dashboard.html');
+  });
+
+  it('exibe erro ao falhar no login', () => {
+    const loginError = new Error('Credenciais inválidas');
+    const signInStub = cy.stub().as('genericSignIn').resolves({ data: null, error: loginError });
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+
+    cy.mockSupabase({
+      genericSignIn: signInStub,
+      createAuditLog: auditStub,
+      getCurrentSession: cy.stub().resolves({ user: null })
+    });
+
+    cy.visit('/login.html');
+    cy.get('#email').type('user@example.com');
+    cy.get('#password').type('SenhaSegura1!');
+    cy.get('#login-form').submit();
+
+    cy.get('#error-message').should('contain', 'Erro no login');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'LOGIN_FAILURE', Cypress.sinon.match({ reason: 'Credenciais inválidas' }));
+    cy.location('pathname').should('eq', '/login.html');
+  });
+
+  it('permite registrar um novo usuário e registra auditoria', () => {
+    const signUpStub = cy.stub().as('signUp').resolves({
+      data: { user: { id: 'new-user', email: 'nova@empresa.com' } },
+      error: null
+    });
+    const profileStub = cy.stub().as('profile').resolves({ success: true });
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+
+    cy.mockSupabase({
+      checkEmailExists: cy.stub().resolves(false),
+      signUpWithEmail: signUpStub,
+      createUserProfile: profileStub,
+      createAuditLog: auditStub
+    });
+
+    cy.clock();
+    cy.visit('/register.html');
+
+    cy.get('#first-name').type('Maria');
+    cy.get('#last-name').type('Silva');
+    cy.get('#email').type('nova@empresa.com');
+    cy.get('#password').type('SenhaSegura1!');
+    cy.get('#confirm-password').type('SenhaSegura1!');
+
+    cy.window().then(win => {
+      win.RegistrationSystem.submit();
+    });
+
+    cy.get('@signUp').should('have.been.calledWith', 'nova@empresa.com', 'SenhaSegura1!');
+    cy.get('@profile').should('have.been.called');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'USER_REGISTERED', Cypress.sinon.match({ email: 'nova@empresa.com' }));
+
+    cy.tick(2000);
+    cy.location('pathname').should('eq', '/login.html');
+  });
+
+  it('impede registro com e-mail duplicado', () => {
+    const warningStub = cy.stub().resolves(false);
+
+    cy.mockSupabase({
+      checkEmailExists: cy.stub().resolves(true),
+      createAuditLog: warningStub
+    });
+
+    cy.visit('/register.html');
+
+    cy.get('#first-name').type('João');
+    cy.get('#last-name').type('Souza');
+    cy.get('#email').type('duplicado@empresa.com');
+    cy.get('#password').type('SenhaSegura1!');
+    cy.get('#confirm-password').type('SenhaSegura1!');
+
+    cy.window().then(win => {
+      win.RegistrationSystem.submit();
+    });
+
+    cy.contains('E-mail já cadastrado').should('be.visible');
+    cy.location('pathname').should('eq', '/register.html');
+  });
+
+  it('envia solicitação de redefinição de senha', () => {
+    const resetStub = cy.stub().as('reset').resolves({ data: {}, error: null });
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+
+    cy.mockSupabase({
+      resetPassword: resetStub,
+      createAuditLog: auditStub
+    });
+
+    cy.visit('/reset-password.html');
+    cy.get('#email').type('user@example.com');
+    cy.get('#reset-form').submit();
+
+    cy.get('#reset-message').should('contain', 'Um link de redefinição');
+    cy.get('@reset').should('have.been.calledWith', 'user@example.com');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'PASSWORD_RESET_REQUEST', Cypress.sinon.match({ email: 'user@example.com' }));
+  });
+
+  it('exibe erro quando redefinição falha', () => {
+    const error = new Error('Falha Supabase');
+    const resetStub = cy.stub().as('reset').resolves({ data: null, error });
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+
+    cy.mockSupabase({
+      resetPassword: resetStub,
+      createAuditLog: auditStub
+    });
+
+    cy.visit('/reset-password.html');
+    cy.get('#email').type('user@example.com');
+    cy.get('#reset-form').submit();
+
+    cy.get('#reset-error').should('contain', 'Falha Supabase');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'PASSWORD_RESET_FAILURE', Cypress.sinon.match({ reason: 'Falha Supabase' }));
+  });
+
+  it('protege rota privada redirecionando usuários não autenticados', () => {
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+    const replaceStub = cy.stub().as('locationReplace');
+
+    cy.mockSupabase({
+      getCurrentSession: cy.stub().resolves({ user: null }),
+      createAuditLog: auditStub,
+      onAuthStateChange: cy.stub().returns({ data: null })
+    });
+
+    cy.clock();
+    cy.visit('/session-guard.html', {
+      onBeforeLoad(win) {
+        win.location.replace = replaceStub;
+      }
+    });
+
+    cy.tick(1500);
+
+    cy.get('@locationReplace').should('have.been.calledWith', '/login.html');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'UNAUTHORIZED_ACCESS', Cypress.sinon.match({ route: '/session-guard.html' }));
+  });
+
+  it('mantém acesso quando a sessão é válida', () => {
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+    const replaceStub = cy.stub().as('locationReplace');
+
+    cy.mockSupabase({
+      getCurrentSession: cy.stub().resolves({ user: { id: 'user-1', email: 'user@example.com' } }),
+      createAuditLog: auditStub,
+      onAuthStateChange: cy.stub().returns({ data: null })
+    });
+
+    cy.visit('/session-guard.html', {
+      onBeforeLoad(win) {
+        win.location.replace = replaceStub;
+      }
+    });
+
+    cy.contains('Sessão válida', { timeout: 5000 }).should('exist');
+    cy.get('@locationReplace').should('not.have.been.called');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'AUTHORIZED_ACCESS', Cypress.sinon.match({ route: '/session-guard.html' }));
+  });
+
+  it('executa logout completo e limpa sessão', () => {
+    const signOutStub = cy.stub().as('signOut').resolves({ success: true });
+    const auditStub = cy.stub().as('auditLog').resolves({ success: true });
+    const sessionStub = cy.stub().resolves({ user: { id: 'user-321', email: 'logout@example.com' } });
+    const userStub = cy.stub().resolves({ id: 'user-321', email: 'logout@example.com' });
+
+    cy.mockSupabase({
+      signOut: signOutStub,
+      createAuditLog: auditStub,
+      getCurrentSession: sessionStub,
+      getCurrentUser: userStub
+    });
+
+    cy.clock();
+    cy.visit('/logout.html');
+
+    cy.window().then(win => {
+      win.localStorage.setItem('alsham_auth_state', '1');
+      win.localStorage.setItem('supabase.auth.token', 'token');
+    });
+
+    cy.get('#logout-button').click();
+
+    cy.get('@signOut').should('have.been.called');
+    cy.get('@auditLog').should('have.been.calledWithMatch', 'USER_LOGGED_OUT', Cypress.sinon.match({ user_id: 'user-321' }));
+
+    cy.tick(1300);
+    cy.location('pathname').should('eq', '/index.html');
+
+    cy.window().then(win => {
+      expect(win.localStorage.getItem('alsham_auth_state')).to.be.null;
+      expect(win.localStorage.getItem('supabase.auth.token')).to.be.null;
+    });
+  });
+});

--- a/tests/e2e/leads.cy.js
+++ b/tests/e2e/leads.cy.js
@@ -1,0 +1,110 @@
+/// <reference types="cypress" />
+
+describe('Gestão de leads (CRUD)', () => {
+  afterEach(() => {
+    cy.mockSupabase(null);
+  });
+
+  it('carrega leads, aplica filtros e reage a operações de criação, atualização e exclusão', () => {
+    const initialLeads = [
+      {
+        id: 'lead-1',
+        name: 'Primeiro Lead',
+        status: 'novo',
+        prioridade: 'alta',
+        origem: 'website',
+        created_at: '2024-01-10T12:00:00.000Z'
+      }
+    ];
+
+    const kpiData = [{ total_leads: 1, convertidos: 0, conversao: 0 }];
+    const gamificationData = [{ points_awarded: 10 }];
+    const automationsData = [{ id: 'auto-1', name: 'Follow-up', is_active: true }];
+
+    let leadsDataset = [...initialLeads];
+    let realtimeHandler;
+
+    const genericSelect = cy.stub().callsFake((table) => {
+      switch (table) {
+        case 'leads_crm':
+          return Promise.resolve({ data: leadsDataset, error: null });
+        case 'dashboard_kpis':
+          return Promise.resolve({ data: kpiData, error: null });
+        case 'gamification_points':
+          return Promise.resolve({ data: gamificationData, error: null });
+        case 'automation_rules':
+          return Promise.resolve({ data: automationsData, error: null });
+        default:
+          return Promise.resolve({ data: [], error: null });
+      }
+    });
+
+    const subscribeToTable = cy.stub().callsFake((table, orgId, callback) => {
+      realtimeHandler = callback;
+      return { unsubscribe: cy.stub() };
+    });
+
+    cy.mockSupabase({
+      getCurrentSession: cy.stub().resolves({ user: { id: 'user-1', email: 'user@example.com' } }),
+      getCurrentOrgId: cy.stub().resolves('org-1'),
+      genericSelect,
+      subscribeToTable
+    });
+
+    cy.visit('/leads-real.html');
+
+    cy.get('#leads-table').within(() => {
+      cy.contains('Primeiro Lead').should('exist');
+      cy.contains('novo').should('exist');
+    });
+
+    cy.get('#filter-search').type('Primeiro');
+    cy.get('#leads-table').within(() => {
+      cy.contains('Primeiro Lead').should('exist');
+    });
+
+    cy.then(() => {
+      leadsDataset = [
+        ...leadsDataset,
+        {
+          id: 'lead-2',
+          name: 'Lead Criado',
+          status: 'contatado',
+          prioridade: 'media',
+          origem: 'indicacao',
+          created_at: '2024-01-11T12:00:00.000Z'
+        }
+      ];
+      realtimeHandler?.();
+    });
+
+    cy.get('#leads-table').within(() => {
+      cy.contains('Lead Criado').should('exist');
+      cy.contains('contatado').should('exist');
+    });
+
+    cy.then(() => {
+      leadsDataset = leadsDataset.map(lead =>
+        lead.id === 'lead-1' ? { ...lead, status: 'convertido' } : lead
+      );
+      realtimeHandler?.();
+    });
+
+    cy.get('#leads-table').within(() => {
+      cy.contains('convertido').should('exist');
+    });
+
+    cy.then(() => {
+      leadsDataset = leadsDataset.filter(lead => lead.id !== 'lead-2');
+      realtimeHandler?.();
+    });
+
+    cy.get('#leads-table').within(() => {
+      cy.contains('Lead Criado').should('not.exist');
+    });
+
+    cy.wrap(null).then(() => {
+      expect(subscribeToTable).to.have.been.calledWith('leads_crm', 'org-1', Cypress.sinon.match.func);
+    });
+  });
+});

--- a/tests/e2e/support/e2e.js
+++ b/tests/e2e/support/e2e.js
@@ -1,0 +1,47 @@
+function createDefaultSupabaseStubs() {
+  const sinon = Cypress.sinon;
+  return {
+    genericSignIn: sinon.stub().resolves({ data: { user: { id: 'default-user', email: 'default@example.com' } }, error: null }),
+    signInWithOAuth: sinon.stub().resolves({ data: {}, error: null }),
+    resetPassword: sinon.stub().resolves({ data: {}, error: null }),
+    getCurrentSession: sinon.stub().resolves({ user: null }),
+    getCurrentUser: sinon.stub().resolves({ id: 'default-user', email: 'default@example.com' }),
+    onAuthStateChange: sinon.stub().returns({ data: null }),
+    signOut: sinon.stub().resolves({ success: true }),
+    createAuditLog: sinon.stub().resolves({ success: true }),
+    healthCheck: sinon.stub().resolves({ status: 'ok' }),
+    checkEmailExists: sinon.stub().resolves(false),
+    signUpWithEmail: sinon.stub().resolves({ data: { user: { id: 'default-user', email: 'default@example.com' } }, error: null }),
+    createUserProfile: sinon.stub().resolves({ success: true }),
+    getCurrentOrgId: sinon.stub().resolves('org-default'),
+    genericSelect: sinon.stub().resolves({ data: [], error: null }),
+    genericInsert: sinon.stub().resolves({ success: true, data: [] }),
+    genericUpdate: sinon.stub().resolves({ success: true, data: [] }),
+    genericDelete: sinon.stub().resolves({ success: true, data: [] }),
+    subscribeToTable: sinon.stub().returns({ unsubscribe: sinon.stub() })
+  };
+}
+
+Cypress.Commands.add('mockSupabase', overrides => {
+  return cy.wrap(null, { log: false }).then(() => {
+    Cypress.env('supabaseStubOverrides', overrides || null);
+  });
+});
+
+afterEach(() => {
+  Cypress.env('supabaseStubOverrides', null);
+});
+
+Cypress.on('window:before:load', win => {
+  const overrides = Cypress.env('supabaseStubOverrides') || {};
+  const baseStubs = createDefaultSupabaseStubs();
+  Object.assign(baseStubs, overrides);
+  win.AlshamSupabase = baseStubs;
+  if (!win.AlshamAuth) {
+    win.AlshamAuth = {
+      isAuthenticated: false,
+      currentUser: null,
+      checkRouteAccess: () => true
+    };
+  }
+});

--- a/tests/unit/supabase.spec.js
+++ b/tests/unit/supabase.spec.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const fromMock = vi.fn();
+let mockClientInstance;
+const createClientMock = vi.fn(() => {
+  mockClientInstance = {
+    from: fromMock,
+    auth: {
+      getSession: vi.fn(),
+      getUser: vi.fn(),
+      signOut: vi.fn(),
+      onAuthStateChange: vi.fn()
+    }
+  };
+  return mockClientInstance;
+});
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: createClientMock
+}));
+
+function createThenable(response) {
+  const chain = {
+    eq: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    then: (resolve, reject) => Promise.resolve(response).then(resolve, reject)
+  };
+  return chain;
+}
+
+describe('Supabase utilitários genéricos', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    fromMock.mockReset();
+    createClientMock.mockClear();
+    mockClientInstance = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('executa genericSelect com filtros, ordenação e limite', async () => {
+    const selectResponse = { data: [{ id: 1 }], error: null };
+    const chain = createThenable(selectResponse);
+    const selectSpy = vi.fn(() => chain);
+
+    fromMock.mockReturnValue({ select: selectSpy });
+
+    const { genericSelect } = await import('../../src/lib/supabase.js');
+    const result = await genericSelect('leads_crm', { org_id: 'org-1' }, {
+      order: { column: 'created_at', ascending: false },
+      limit: 5
+    });
+
+    expect(result).toEqual({ data: selectResponse.data });
+    expect(selectSpy).toHaveBeenCalledWith('*');
+    expect(chain.eq).toHaveBeenCalledWith('org_id', 'org-1');
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+    expect(chain.limit).toHaveBeenCalledWith(5);
+  });
+
+  it('retorna erro normalizado no genericSelect', async () => {
+    const error = new Error('falha select');
+    const chain = createThenable({ data: null, error });
+    const selectSpy = vi.fn(() => chain);
+    fromMock.mockReturnValue({ select: selectSpy });
+
+    const { genericSelect } = await import('../../src/lib/supabase.js');
+    const result = await genericSelect('leads_crm', { org_id: 'org-1' });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toMatchObject({ message: 'falha select', context: 'select:leads_crm' });
+  });
+
+  it('insere registros com genericInsert anexando org_id', async () => {
+    const insertResponse = { data: [{ id: '1', name: 'Lead' }], error: null };
+    const chain = createThenable(insertResponse);
+    const selectSpy = vi.fn(() => chain);
+    const insertSpy = vi.fn(() => ({ select: selectSpy }));
+
+    fromMock.mockReturnValue({ insert: insertSpy });
+
+    const { genericInsert } = await import('../../src/lib/supabase.js');
+    const payload = { name: 'Lead' };
+    const result = await genericInsert('leads_crm', payload, 'org-55');
+
+    expect(insertSpy).toHaveBeenCalledWith({ name: 'Lead', org_id: 'org-55' });
+    expect(result).toEqual({ success: true, data: insertResponse.data });
+  });
+
+  it('propaga erros no genericInsert', async () => {
+    const error = new Error('falha insert');
+    const chain = createThenable({ data: null, error });
+    const selectSpy = vi.fn(() => chain);
+    const insertSpy = vi.fn(() => ({ select: selectSpy }));
+    fromMock.mockReturnValue({ insert: insertSpy });
+
+    const { genericInsert } = await import('../../src/lib/supabase.js');
+    const result = await genericInsert('leads_crm', { name: 'Lead' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatchObject({ message: 'falha insert', context: 'insert:leads_crm' });
+  });
+
+  it('registra auditoria com createAuditLog usando org fornecido', async () => {
+    vi.useFakeTimers();
+    const fixedDate = new Date('2024-03-01T10:00:00.000Z');
+    vi.setSystemTime(fixedDate);
+
+    const response = { data: [{ id: 'log-1' }], error: null };
+    const chain = createThenable(response);
+    const selectSpy = vi.fn(() => chain);
+    const insertSpy = vi.fn(() => ({ select: selectSpy }));
+
+    fromMock.mockImplementation(table => {
+      if (table === 'audit_log') {
+        return { insert: insertSpy };
+      }
+      return { select: vi.fn(() => createThenable({ data: [], error: null })) };
+    });
+
+    const { createAuditLog } = await import('../../src/lib/supabase.js');
+    const result = await createAuditLog('ACTION_TEST', { foo: 'bar' }, 'user-1', 'org-88');
+
+    expect(insertSpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'ACTION_TEST',
+      details: { foo: 'bar' },
+      user_id: 'user-1',
+      org_id: 'org-88',
+      created_at: fixedDate.toISOString()
+    }));
+    expect(result).toEqual({ success: true, data: response.data });
+  });
+
+  it('obtém org atual ao criar auditoria sem org explícito', async () => {
+    const response = { data: [{ id: 'log-2' }], error: null };
+    const auditChain = createThenable(response);
+    const auditSelectSpy = vi.fn(() => auditChain);
+    const auditInsertSpy = vi.fn(() => ({ select: auditSelectSpy }));
+
+    const resolvedOrgId = '11111111-1111-4111-8111-111111111111';
+    const profileResponse = { data: { org_id: resolvedOrgId }, error: null };
+    const profileChain = {
+      eq: vi.fn(() => profileChain),
+      limit: vi.fn(() => profileChain),
+      maybeSingle: vi.fn(() => profileChain),
+      then: (resolve, reject) => Promise.resolve(profileResponse).then(resolve, reject)
+    };
+    const profileSelectSpy = vi.fn(() => profileChain);
+
+    fromMock.mockImplementation(table => {
+      if (table === 'audit_log') {
+        return { insert: auditInsertSpy };
+      }
+      if (table === 'user_profiles') {
+        return { select: profileSelectSpy };
+      }
+      return { select: vi.fn(() => createThenable({ data: [], error: null })) };
+    });
+
+    const module = await import('../../src/lib/supabase.js');
+    mockClientInstance.auth.getSession.mockResolvedValue({ data: { session: { user: { id: 'user-9' } } }, error: null });
+
+    const result = await module.createAuditLog('ACTION', { foo: 'bar' }, 'user-9');
+
+    expect(profileSelectSpy).toHaveBeenCalledWith('org_id');
+    expect(auditInsertSpy).toHaveBeenCalledWith(expect.objectContaining({ org_id: resolvedOrgId }));
+    expect(result.success).toBe(true);
+  });
+
+  it('retorna erro quando createAuditLog falha', async () => {
+    const error = new Error('falha audit');
+    const chain = createThenable({ data: null, error });
+    const selectSpy = vi.fn(() => chain);
+    const insertSpy = vi.fn(() => ({ select: selectSpy }));
+
+    fromMock.mockImplementation(table => ({ insert: insertSpy }));
+
+    const { createAuditLog } = await import('../../src/lib/supabase.js');
+    const result = await createAuditLog('ACTION_FAIL', {}, 'user-1', 'org-1');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatchObject({ message: 'falha audit', context: 'auditLog' });
+  });
+});


### PR DESCRIPTION
## Summary
- configure Cypress with custom support stubs and add end-to-end specs covering authentication flows, route protection, and leads CRUD behaviour based on the audit checklist
- add Vitest unit tests for Supabase helpers genericSelect, genericInsert and createAuditLog, including success and failure scenarios
- update npm scripts and dev dependencies and add a CI workflow that runs both unit and E2E suites on pull requests

## Testing
- npm run test:unit
- npm run test:e2e *(fails: Cypress binary download blocked by proxy in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d799d487908326af516216f17b394c