### PR TITLE
Add Cypress and Vitest test scaffolding with CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: CI Tests
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Run end-to-end tests
+        run: npm run test:e2e
+        env:
+          CI: '1'

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  video: false,
+  screenshotOnRunFailure: true,
+  e2e: {
+    baseUrl: 'http://127.0.0.1:4173',
+    specPattern: 'tests/e2e/**/*.cy.js',
+    supportFile: 'tests/e2e/support/e2e.js',
+    fixturesFolder: false
+  }
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "fresh-install": "npm run clean && npm install",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix",
-    "test": "vitest run",
+    "test": "npm run test:unit",
+    "test:unit": "vitest run",
+    "test:e2e": "start-server-and-test \"npm run preview -- --host 127.0.0.1 --port 4173\" http://127.0.0.1:4173 \"cypress run\"",
     "test:coverage": "vitest run --coverage"
   },
   "keywords": [
@@ -69,7 +71,9 @@
     "nodemon": "^3.1.7",
     "eslint": "^9.15.0",
     "vitest": "^2.1.4",
-    "@vitest/coverage-v8": "^2.1.4"
+    "@vitest/coverage-v8": "^2.1.4",
+    "cypress": "^13.15.1",
+    "start-server-and-test": "^2.0.3"
   },
   "repository": {
     "type": "git",

--- a/tests/e2e/auth.cy.js
+++ b/tests/e2e/auth.cy.js
@@ -1,0 +1,92 @@
+const { sinon } = Cypress;
+
+describe('Fluxos de autenticação', () => {
+  it('realiza login com credenciais válidas', () => {
+    cy.visit('/login.html', {
+      onBeforeLoad(win) {
+        win.__supabaseTestOverrides = {
+          getCurrentSession: sinon.stub().resolves({ user: null }),
+          getCurrentUser: sinon.stub().resolves(null)
+        };
+      }
+    });
+
+    cy.clock();
+    cy.get('#email').type('usuario@alsham.com');
+    cy.get('#password').type('SenhaForte@123');
+    cy.get('#login-form').submit();
+
+    cy.contains('Login realizado com sucesso!', { timeout: 5000 }).should('be.visible');
+    cy.tick(1100);
+
+    cy.window().its('__testNavigations').should('include', '/dashboard.html');
+    cy.window().its('__supabaseStubs.createAuditLog').should('have.been.calledWith', 'LOGIN_SUCCESS', sinon.match.object);
+  });
+
+  it('registra um novo usuário com sucesso', () => {
+    const signUpStub = sinon.stub().callsFake((email) => Promise.resolve({
+      data: { user: { id: 'user-789', email } }
+    }));
+
+    cy.visit('/register.html', {
+      onBeforeLoad(win) {
+        win.__supabaseTestOverrides = {
+          checkEmailExists: sinon.stub().resolves(false),
+          signUpWithEmail: signUpStub
+        };
+      }
+    });
+
+    cy.clock();
+    cy.get('#first-name').type('Teste');
+    cy.get('#last-name').type('Usuário');
+    cy.get('#email').type('novo@alsham.com');
+    cy.get('#submit-button').click();
+
+    cy.get('#password').type('SenhaUltra@123', { force: true });
+    cy.get('#confirm-password').type('SenhaUltra@123', { force: true });
+    cy.get('#submit-button').click();
+
+    cy.get('#verification-code').type('123456', { force: true });
+    cy.get('#submit-button').click();
+
+    cy.contains('Conta criada!', { timeout: 5000 }).should('be.visible');
+    cy.tick(2100);
+
+    cy.window().its('__testNavigations').should('include', '/login.html');
+    cy.window().its('__supabaseStubs.createAuditLog').should('have.been.calledWith', 'USER_REGISTERED', sinon.match.object);
+  });
+
+  it('envia e-mail de redefinição de senha', () => {
+    cy.visit('/reset-password.html', {
+      onBeforeLoad(win) {
+        win.__supabaseTestOverrides = {
+          resetPassword: sinon.stub().resolves({ data: { status: 'sent' } })
+        };
+      }
+    });
+
+    cy.get('#email').type('usuario@alsham.com');
+    cy.get('#reset-form').submit();
+
+    cy.contains('✅ Um link de redefinição foi enviado para seu e-mail.', { timeout: 5000 }).should('be.visible');
+    cy.window().its('__supabaseStubs.createAuditLog').should('have.been.calledWith', 'PASSWORD_RESET_REQUEST', sinon.match.object);
+  });
+
+  it('encerra a sessão do usuário', () => {
+    cy.visit('/logout.html', {
+      onBeforeLoad(win) {
+        win.__supabaseTestOverrides = {
+          getCurrentSession: sinon.stub().resolves({ user: { id: 'user-123', email: 'usuario@alsham.com' } })
+        };
+      }
+    });
+
+    cy.clock();
+    cy.contains('Sair com segurança').click();
+    cy.tick(1300);
+
+    cy.window().its('__testNavigations').should('include', '/index.html');
+    cy.window().its('__supabaseStubs.createAuditLog').should('have.been.calledWith', 'USER_LOGGED_OUT', sinon.match.object);
+  });
+});

--- a/tests/e2e/leads.cy.js
+++ b/tests/e2e/leads.cy.js
@@ -1,0 +1,63 @@
+describe('Gestão de Leads (CRUD)', () => {
+  it('sincroniza lista de leads com eventos realtime', () => {
+    cy.visit('/leads-real.html', {
+      onBeforeLoad(win) {
+        const now = new Date().toISOString();
+        win.__supabaseTestState = {
+          leads: [
+            {
+              id: 'lead-1',
+              name: 'Lead Inicial',
+              status: 'novo',
+              prioridade: 'alta',
+              origem: 'website',
+              created_at: now
+            }
+          ],
+          kpis: {
+            total_leads: 1,
+            convertidos: 0,
+            conversao: 0
+          },
+          gamification: [{ points_awarded: 25 }],
+          automations: [{ id: 'auto-1', name: 'Boas-vindas', is_active: true }],
+          auditLogs: []
+        };
+      }
+    });
+
+    cy.contains('#leads-table', 'Lead Inicial', { timeout: 5000 }).should('be.visible');
+
+    cy.updateSupabaseState(state => {
+      state.leads.push({
+        id: 'lead-2',
+        name: 'Lead Criado',
+        status: 'novo',
+        prioridade: 'media',
+        origem: 'linkedin',
+        created_at: new Date().toISOString()
+      });
+    });
+    cy.triggerSupabaseRealtime();
+    cy.contains('#leads-table', 'Lead Criado', { timeout: 5000 }).should('be.visible');
+
+    cy.updateSupabaseState(state => {
+      const lead = state.leads.find(item => item.id === 'lead-2');
+      if (lead) {
+        lead.name = 'Lead Atualizado';
+        lead.status = 'qualificado';
+      }
+    });
+    cy.triggerSupabaseRealtime();
+    cy.contains('#leads-table', 'Lead Atualizado', { timeout: 5000 }).should('be.visible');
+
+    cy.updateSupabaseState(state => {
+      const index = state.leads.findIndex(item => item.id === 'lead-2');
+      if (index >= 0) {
+        state.leads.splice(index, 1);
+      }
+    });
+    cy.triggerSupabaseRealtime();
+    cy.contains('#leads-table', 'Lead Atualizado').should('not.exist');
+  });
+});

--- a/tests/e2e/session-guard.cy.js
+++ b/tests/e2e/session-guard.cy.js
@@ -1,0 +1,41 @@
+const { sinon } = Cypress;
+
+describe('Proteção de rotas com Session Guard', () => {
+  it('redireciona visitantes não autenticados', () => {
+    cy.visit('/session-guard.html', {
+      onBeforeLoad(win) {
+        win.__supabaseTestOverrides = {
+          getCurrentSession: sinon.stub().resolves({ user: null })
+        };
+        win.AlshamAuth = { isAuthenticated: false };
+      }
+    });
+
+    cy.wait(1300);
+    cy.window().its('__testNavigations').should('include', '/login.html');
+
+    cy.window().its('__supabaseTestHelpers.state.auditLogs').then(logs => {
+      const found = logs.some(log => log.action === 'UNAUTHORIZED_ACCESS');
+      expect(found, 'audit log de acesso não autorizado').to.be.true;
+    });
+  });
+
+  it('permite acesso para usuários autenticados', () => {
+    cy.visit('/session-guard.html', {
+      onBeforeLoad(win) {
+        win.__supabaseTestOverrides = {
+          getCurrentSession: sinon.stub().resolves({
+            user: { id: 'user-777', email: 'auth@alsham.com', user_metadata: { org_id: 'org-test-123' } }
+          })
+        };
+      }
+    });
+
+    cy.contains('#user-info', 'auth@alsham.com', { timeout: 5000 }).should('be.visible');
+
+    cy.window().its('__supabaseTestHelpers.state.auditLogs').then(logs => {
+      const found = logs.some(log => log.action === 'AUTHORIZED_ACCESS');
+      expect(found, 'audit log de acesso autorizado').to.be.true;
+    });
+  });
+});

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1,0 +1,15 @@
+Cypress.Commands.add('updateSupabaseState', updater => {
+  cy.window().then(win => {
+    const helpers = win.__supabaseTestHelpers;
+    if (helpers?.state && typeof updater === 'function') {
+      updater(helpers.state);
+    }
+  });
+});
+
+Cypress.Commands.add('triggerSupabaseRealtime', payload => {
+  cy.window().then(win => {
+    const helpers = win.__supabaseTestHelpers;
+    helpers?.notifyRealtime(payload);
+  });
+});

--- a/tests/e2e/support/e2e.js
+++ b/tests/e2e/support/e2e.js
@@ -1,0 +1,6 @@
+import './commands.js';
+import { applySupabaseStubs } from './supabase-stubs.js';
+
+Cypress.on('window:before:load', win => {
+  applySupabaseStubs(win);
+});

--- a/tests/e2e/support/supabase-stubs.js
+++ b/tests/e2e/support/supabase-stubs.js
@@ -1,0 +1,261 @@
+const DEFAULT_USER = {
+  id: 'user-123',
+  email: 'user@example.com',
+  user_metadata: { org_id: 'org-test-123' }
+};
+
+const DEFAULT_STATE = () => {
+  const now = new Date().toISOString();
+  return {
+    leads: [
+      {
+        id: 'lead-1',
+        name: 'Lead Inicial',
+        status: 'novo',
+        prioridade: 'alta',
+        origem: 'website',
+        created_at: now
+      }
+    ],
+    kpis: {
+      total_leads: 1,
+      convertidos: 0,
+      conversao: 0
+    },
+    gamification: [
+      { points_awarded: 10 }
+    ],
+    automations: [
+      { id: 'auto-1', name: 'Fluxo de boas-vindas', is_active: true }
+    ],
+    auditLogs: []
+  };
+};
+
+function ensureNavigationStub(win) {
+  if (win.__navigationStubbed) return;
+  win.__testNavigations = [];
+  const pushNavigation = url => {
+    if (!url) return;
+    win.__testNavigations.push(url);
+  };
+  const location = win.location;
+  const proto = Object.getPrototypeOf(location);
+  const hrefDescriptor = Object.getOwnPropertyDescriptor(proto, 'href');
+  if (hrefDescriptor) {
+    Object.defineProperty(location, 'href', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return hrefDescriptor.get.call(location);
+      },
+      set(value) {
+        pushNavigation(value);
+      }
+    });
+  }
+  if (typeof location.assign === 'function') {
+    location.assign = url => {
+      pushNavigation(url);
+    };
+  }
+  if (typeof location.replace === 'function') {
+    location.replace = url => {
+      pushNavigation(url);
+    };
+  }
+  win.__navigationStubbed = true;
+}
+
+function createDefaultApi(win, state, realtimeCallbacks) {
+  const sinon = Cypress.sinon;
+
+  const notifyRealtime = payload => {
+    realtimeCallbacks.forEach(cb => {
+      try {
+        cb(payload);
+      } catch (error) {
+        console.error('Realtime callback error', error);
+      }
+    });
+  };
+
+  const genericSelect = sinon.stub().callsFake((table) => {
+    switch (table) {
+      case 'leads_crm':
+        return Promise.resolve({ data: [...state.leads], error: null });
+      case 'dashboard_kpis':
+        return Promise.resolve({ data: [state.kpis], error: null });
+      case 'gamification_points':
+        return Promise.resolve({ data: [...state.gamification], error: null });
+      case 'automation_rules':
+        return Promise.resolve({ data: [...state.automations], error: null });
+      default:
+        return Promise.resolve({ data: [], error: null });
+    }
+  });
+
+  const genericInsert = sinon.stub().callsFake((table, payload) => {
+    if (table === 'leads_crm') {
+      const newLead = {
+        id: payload.id || `lead-${Date.now()}`,
+        created_at: payload.created_at || new Date().toISOString(),
+        ...payload
+      };
+      state.leads.push(newLead);
+      notifyRealtime({ eventType: 'INSERT', new: newLead });
+      return Promise.resolve({ success: true, data: [newLead] });
+    }
+    return Promise.resolve({ success: true, data: [payload] });
+  });
+
+  const genericUpdate = sinon.stub().callsFake((table, id, updates) => {
+    if (table === 'leads_crm') {
+      const lead = state.leads.find(item => item.id === id);
+      if (lead) {
+        Object.assign(lead, updates);
+        notifyRealtime({ eventType: 'UPDATE', new: { ...lead } });
+        return Promise.resolve({ success: true, data: [lead] });
+      }
+      return Promise.resolve({ success: false, error: { message: 'Lead not found' } });
+    }
+    return Promise.resolve({ success: true, data: [updates] });
+  });
+
+  const genericDelete = sinon.stub().callsFake((table, id) => {
+    if (table === 'leads_crm') {
+      const index = state.leads.findIndex(item => item.id === id);
+      if (index !== -1) {
+        const [removed] = state.leads.splice(index, 1);
+        notifyRealtime({ eventType: 'DELETE', old: removed });
+        return Promise.resolve({ success: true, data: [removed] });
+      }
+      return Promise.resolve({ success: false, error: { message: 'Lead not found' } });
+    }
+    return Promise.resolve({ success: true, data: [] });
+  });
+
+  const createAuditLog = sinon.stub().callsFake((action, details) => {
+    state.auditLogs.push({ action, details });
+    return Promise.resolve({ success: true });
+  });
+
+  const subscribeToTable = sinon.stub().callsFake((table, orgId, callback) => {
+    if (typeof callback === 'function') {
+      const wrapped = payload => callback(payload);
+      realtimeCallbacks.push(wrapped);
+      return {
+        unsubscribe: () => {
+          const idx = realtimeCallbacks.indexOf(wrapped);
+          if (idx >= 0) realtimeCallbacks.splice(idx, 1);
+        }
+      };
+    }
+    return { unsubscribe: () => {} };
+  });
+
+  const getCurrentSession = sinon.stub().resolves({ user: DEFAULT_USER });
+  const getCurrentUser = sinon.stub().resolves(DEFAULT_USER);
+  const getCurrentOrgId = sinon.stub().resolves('org-test-123');
+  const getDefaultOrgId = sinon.stub().returns('org-test-123');
+  const signOut = sinon.stub().resolves({ success: true });
+  const onAuthStateChange = sinon.stub().callsFake((callback) => {
+    if (typeof callback === 'function') {
+      callback('SIGNED_IN', { user: DEFAULT_USER });
+    }
+    return { data: { subscription: { unsubscribe: sinon.stub() } } };
+  });
+  const genericSignIn = sinon.stub().callsFake((email) => {
+    return Promise.resolve({ data: { user: { ...DEFAULT_USER, email } }, error: null });
+  });
+  const signInWithOAuth = sinon.stub().resolves({ data: {} });
+  const resetPassword = sinon.stub().resolves({ data: { status: 'sent' } });
+  const signUpWithEmail = sinon.stub().callsFake((email) => {
+    return Promise.resolve({ data: { user: { id: 'user-456', email } }, error: null });
+  });
+  const createUserProfile = sinon.stub().callsFake(profile => {
+    return Promise.resolve({ success: true, data: [{ ...profile }] });
+  });
+  const checkEmailExists = sinon.stub().resolves(false);
+  const healthCheck = sinon.stub().resolves({ ok: true });
+
+  return {
+    DEFAULT_ORG_ID: 'org-test-123',
+    supabase: {},
+    supabaseClient: {},
+    getDefaultOrgId,
+    getCurrentOrgId,
+    getCurrentSession,
+    getCurrentUser,
+    signOut,
+    onAuthStateChange,
+    genericSignIn,
+    signInWithOAuth,
+    resetPassword,
+    signUpWithEmail,
+    createUserProfile,
+    checkEmailExists,
+    createAuditLog,
+    genericSelect,
+    genericInsert,
+    genericUpdate,
+    genericDelete,
+    subscribeToTable,
+    createAuditLogForTests: createAuditLog,
+    createLead: genericInsert,
+    healthCheck
+  };
+}
+
+export function applySupabaseStubs(win) {
+  ensureNavigationStub(win);
+
+  if (!win.__supabaseRealtimeCallbacks) {
+    win.__supabaseRealtimeCallbacks = [];
+  }
+  const realtimeCallbacks = win.__supabaseRealtimeCallbacks;
+
+  if (!win.__supabaseTestState) {
+    win.__supabaseTestState = DEFAULT_STATE();
+  }
+  const state = win.__supabaseTestState;
+
+  if (!win.Chart) {
+    win.Chart = class {
+      constructor() {}
+      destroy() {}
+    };
+  }
+
+  if (!win.AlshamAuth) {
+    win.AlshamAuth = {
+      isAuthenticated: true,
+      currentUser: DEFAULT_USER
+    };
+  }
+
+  if (!win.showToast) {
+    win.showToast = () => {};
+  }
+
+  const defaultApi = createDefaultApi(win, state, realtimeCallbacks);
+  const overrides = win.__supabaseTestOverrides || {};
+  const api = { ...defaultApi, ...overrides };
+
+  win.AlshamSupabase = api;
+  win.supabaseClient = api;
+  win.__supabaseStubs = api;
+  win.__supabaseTestHelpers = {
+    state,
+    realtimeCallbacks,
+    notifyRealtime: payload => {
+      realtimeCallbacks.forEach(cb => {
+        try {
+          cb(payload);
+        } catch (error) {
+          console.error('Realtime callback error', error);
+        }
+      });
+    }
+  };
+}

--- a/tests/unit/supabase.spec.js
+++ b/tests/unit/supabase.spec.js
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const responses = new Map();
+let queries = [];
+
+const mockSupabase = {
+  from: vi.fn()
+};
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => mockSupabase)
+}));
+
+function queueResponse(table, response) {
+  if (!responses.has(table)) {
+    responses.set(table, []);
+  }
+  responses.get(table).push(response);
+}
+
+function makeQuery(table) {
+  const query = {
+    table,
+    calls: {
+      select: [],
+      eq: [],
+      order: [],
+      limit: [],
+      insert: [],
+      update: [],
+      delete: 0
+    }
+  };
+
+  query.select = vi.fn(arg => {
+    query.calls.select.push(arg);
+    return query;
+  });
+  query.eq = vi.fn((column, value) => {
+    query.calls.eq.push([column, value]);
+    return query;
+  });
+  query.order = vi.fn((column, options) => {
+    query.calls.order.push([column, options]);
+    return query;
+  });
+  query.limit = vi.fn(value => {
+    query.calls.limit.push(value);
+    return query;
+  });
+  query.insert = vi.fn(payload => {
+    query.calls.insert.push(payload);
+    return query;
+  });
+  query.update = vi.fn(payload => {
+    query.calls.update.push(payload);
+    return query;
+  });
+  query.delete = vi.fn(() => {
+    query.calls.delete += 1;
+    return query;
+  });
+  query.select.mockName(`select:${table}`);
+  query.eq.mockName(`eq:${table}`);
+  query.order.mockName(`order:${table}`);
+  query.limit.mockName(`limit:${table}`);
+  query.insert.mockName(`insert:${table}`);
+  query.update.mockName(`update:${table}`);
+  query.delete.mockName(`delete:${table}`);
+
+  query.then = (resolve, reject) => {
+    const queue = responses.get(table) || [];
+    const result = queue.length ? queue.shift() : { data: null, error: null };
+    return Promise.resolve(result).then(resolve, reject);
+  };
+
+  return query;
+}
+
+beforeEach(() => {
+  responses.clear();
+  queries = [];
+  mockSupabase.from.mockReset();
+  mockSupabase.from.mockImplementation(table => {
+    const query = makeQuery(table);
+    queries.push(query);
+    return query;
+  });
+});
+
+const { genericSelect, genericInsert, createAuditLog } = await import('../../src/lib/supabase.js');
+
+describe('genericSelect', () => {
+  it('retorna dados filtrados com ordenação e limite', async () => {
+    queueResponse('example_table', { data: [{ id: 1, name: 'Lead' }], error: null });
+
+    const result = await genericSelect('example_table', { org_id: 'org-123', status: '' }, {
+      select: 'id,name',
+      order: { column: 'created_at', ascending: false },
+      limit: 5
+    });
+
+    expect(result.data).toEqual([{ id: 1, name: 'Lead' }]);
+    const query = queries.find(q => q.table === 'example_table');
+    expect(query).toBeTruthy();
+    expect(query.calls.select[0]).toBe('id,name');
+    expect(query.calls.eq).toContainEqual(['org_id', 'org-123']);
+    const appliedColumns = query.calls.eq.map(([column]) => column);
+    expect(appliedColumns).not.toContain('status');
+    expect(query.calls.order).toContainEqual(['created_at', { ascending: false }]);
+    expect(query.calls.limit).toContain(5);
+  });
+});
+
+describe('genericInsert', () => {
+  it('anexa org_id quando fornecido e retorna dados inseridos', async () => {
+    queueResponse('leads_crm', { data: [{ id: 'lead-1', name: 'Teste', org_id: 'org-abc' }], error: null });
+
+    const payload = { name: 'Teste' };
+    const result = await genericInsert('leads_crm', payload, 'org-abc');
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual([{ id: 'lead-1', name: 'Teste', org_id: 'org-abc' }]);
+
+    const query = queries.find(q => q.table === 'leads_crm');
+    expect(query.calls.insert[0]).toEqual({ name: 'Teste', org_id: 'org-abc' });
+  });
+});
+
+describe('createAuditLog', () => {
+  it('registra logs com action, detalhes e org', async () => {
+    queueResponse('audit_log', { data: [{ id: 'log-1' }], error: null });
+
+    const result = await createAuditLog('LOGIN_SUCCESS', { email: 'user@alsham.com' }, 'user-123', 'org-xyz');
+
+    expect(result.success).toBe(true);
+    const query = queries.find(q => q.table === 'audit_log');
+    expect(query).toBeTruthy();
+    const [inserted] = query.calls.insert;
+    expect(inserted).toMatchObject({
+      action: 'LOGIN_SUCCESS',
+      details: { email: 'user@alsham.com' },
+      user_id: 'user-123',
+      org_id: 'org-xyz'
+    });
+    expect(typeof inserted.created_at).toBe('string');
+    expect(Number.isNaN(Date.parse(inserted.created_at))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold Cypress end-to-end tests for authentication flows, session guard, and leads realtime CRUD using Supabase stubs
- add Vitest unit coverage for supabase genericSelect/genericInsert/createAuditLog helpers
- configure npm scripts, Cypress config, and GitHub Actions workflow to run unit and e2e tests in CI

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d799c29508832684467493de954228